### PR TITLE
add error handling on branch initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,6 @@
     
 ## 0.0.2+2
     - Upgrade Kotlin version to 1.3.21
+    
+# 0.0.3
+    - Notify on Android if branch io can't be initialized

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Implemented function:
 - After your AppDelegate has been tweaked, you could use some of the functions below
 - Last, you need to call this code inside your application's initState
     ```
-        if (Platform.isAndroid) FlutterBranchIoPlugin.setupBranchIO();
+        if (Platform.isAndroid) FlutterBranchIoPlugin.setupBranchIO(); // will throw an exception if it fails
         FlutterBranchIoPlugin.listenToDeepLinkStream().listen((string) {
           print("DEEPLINK $string");
           // PROCESS DEEPLINK HERE
@@ -78,7 +78,7 @@ Implemented function:
 
     - Last, you need to call this code inside your application's initState
     ```
-        if (Platform.isAndroid) FlutterBranchIoPlugin.setupBranchIO();
+        if (Platform.isAndroid) FlutterBranchIoPlugin.setupBranchIO();  // will throw an exception if it fails
         FlutterBranchIoPlugin.listenToDeepLinkStream().listen((string) {
           print("DEEPLINK $string");
           // PROCESS DEEPLINK HERE
@@ -190,7 +190,9 @@ to list an universal object on google search, you can use
     - Change README's obsolete instructions for Android
 - 0.0.2+2
     - Upgrade Kotlin version to 1.3.21
+- 0.0.3
+    - Notify on Android if branch io can't be initialized
 
 # Contributor
-- Angga Dwi Arifandi (angga.dwi@oval.id)
+- Angga Dwi Arifandi (anggadwiarifandi96@gmail.com)
 - Abdul Ghapur (gofur@oval.id)

--- a/android/src/main/kotlin/com/anggach/flutterbranchioplugin/FlutterBranchIoPlugin.kt
+++ b/android/src/main/kotlin/com/anggach/flutterbranchioplugin/FlutterBranchIoPlugin.kt
@@ -46,8 +46,7 @@ class FlutterBranchIoPlugin(private var registrar: Registrar) : MethodCallHandle
     override fun onMethodCall(call: MethodCall, result: Result) {
         when {
             call.method == "initBranchIO" -> {
-                result.success("INITIALIZING BRANCH IO")
-                setUpBranchIo(registrar, deepLinkStreamHandler)
+                setUpBranchIo(registrar, deepLinkStreamHandler, result)
             }
             call.method == "generateLink" -> {
                 generateLinkHandler(this.registrar, generatedLinkStreamHandler, call)

--- a/android/src/main/kotlin/com/anggach/flutterbranchioplugin/src/Initializer.kt
+++ b/android/src/main/kotlin/com/anggach/flutterbranchioplugin/src/Initializer.kt
@@ -8,6 +8,7 @@ import io.branch.referral.Branch
 import io.branch.referral.BranchError
 import io.branch.referral.BranchUtil
 import io.flutter.plugin.common.PluginRegistry
+import io.flutter.plugin.common.MethodChannel.Result
 import org.json.JSONObject
 
 
@@ -25,17 +26,18 @@ fun init(registrar: PluginRegistry.Registrar) {
     Branch.getAutoInstance(registrar.activity().applicationContext)
 }
 
-fun setUpBranchIo(registrar: PluginRegistry.Registrar, deepLinkStreamHandler: DeepLinkStreamHandler?) {
+fun setUpBranchIo(registrar: PluginRegistry.Registrar, deepLinkStreamHandler: DeepLinkStreamHandler?, result: Result) {
     init(registrar)
     Branch.getInstance().initSession({ referringParams: JSONObject?, error: BranchError? ->
         Log.d(DEBUG_NAME, "BRANCH CALLBACK")
         if (error == null) {
+            result.success("BRANCH IO INITIALIZED")
             val params = referringParams?.toString()
             val intent = Intent()
             intent.putExtra(INTENT_EXTRA_DATA, params)
             deepLinkStreamHandler!!.handleIntent(registrar.activity(), intent)
         } else {
-            Log.i(DEBUG_NAME, error.message)
+            result.error("1", "BRANCH IO INITIALIZATION ERROR ${error.message}", null)
         }
     }, registrar.activity().intent.data, registrar.activity())
 

--- a/android/src/main/kotlin/com/anggach/flutterbranchioplugin/src/StreamHandler.kt
+++ b/android/src/main/kotlin/com/anggach/flutterbranchioplugin/src/StreamHandler.kt
@@ -54,7 +54,7 @@ class DeepLinkStreamHandler: EventChannel.StreamHandler {
     }
 
     override fun onListen(p0: Any?, events: EventChannel.EventSink?) {
-        Log.d(DEBUG_NAME, "ON LIstEN")
+        Log.d(DEBUG_NAME, "ON LISTEN")
         receiver = createReceiver(events)
     }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,3 @@
-package example.android
-
 buildscript {
     ext.kotlin_version = '1.3.21'
     repositories {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,11 +14,27 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   String _data = '-';
   String generatedLink = '-';
+  String error = '-';
 
   @override
   void initState() {
     super.initState();
-    if (Platform.isAndroid) FlutterBranchIoPlugin.setupBranchIO();
+
+    try {
+      setUpBranch();
+    } catch (error) {
+      setState(() {
+        this.error = error.toString();
+      });
+      print("BRANCH ERROR ${error.toString()}");
+    }
+  }
+
+  void setUpBranch() {
+    if (Platform.isAndroid) {
+      FlutterBranchIoPlugin.setupBranchIO();
+    }
+
     FlutterBranchIoPlugin.listenToDeepLinkStream().listen((string) {
       print("DEEPLINK $string");
       setState(() {
@@ -41,20 +57,20 @@ class _MyAppState extends State<MyApp> {
     });
 
     FlutterBranchIoPlugin.generateLink(
-      FlutterBranchUniversalObject()
-          .setCanonicalIdentifier("content/12345")
-          .setTitle("My Content Title")
-          .setContentDescription("My Content Description")
-          .setContentImageUrl("https://lorempixel.com/400/400")
-          .setContentIndexingMode(BUO_CONTENT_INDEX_MODE.PUBLIC)
-          .setLocalIndexMode(BUO_CONTENT_INDEX_MODE.PUBLIC),
-      lpChannel: "facebook",
-      lpFeature: "sharing",
-      lpCampaign: "content 123 launch",
-      lpStage: "new user",
-      lpControlParams: {
-        "url": "http://www.google.com"
-      }
+        FlutterBranchUniversalObject()
+            .setCanonicalIdentifier("content/12345")
+            .setTitle("My Content Title")
+            .setContentDescription("My Content Description")
+            .setContentImageUrl("https://lorempixel.com/400/400")
+            .setContentIndexingMode(BUO_CONTENT_INDEX_MODE.PUBLIC)
+            .setLocalIndexMode(BUO_CONTENT_INDEX_MODE.PUBLIC),
+        lpChannel: "facebook",
+        lpFeature: "sharing",
+        lpCampaign: "content 123 launch",
+        lpStage: "new user",
+        lpControlParams: {
+          "url": "http://www.google.com"
+        }
     );
 
     FlutterBranchIoPlugin.trackContent( FlutterBranchUniversalObject()
@@ -93,6 +109,12 @@ class _MyAppState extends State<MyApp> {
                       "GENERATED LINK $generatedLink"
                   ),
                 ),
+                error.isEmpty ? Container() : Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: Text(
+                      "ERROR: $error"
+                  ),
+                )
               ],
             ),
           );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_branch_io_plugin
 description: A new Flutter plugin to port Branch IO SDK.
-version: 0.0.2+2
-author: Angga Dwi Arifandi <angga.dwi@oval.id>
+version: 0.0.3
+author: Angga Dwi Arifandi <anggadwiarifandi96@gmail.com>
 homepage: https://github.com/blackmenthor/flutter-branch-io
 
 environment:


### PR DESCRIPTION
closes #13 

from now on, whenever a call to `FlutterBranchIoPlugin.setupBranchIo` fails initializing, it'll throw a `PlatformException` with the details inside the message